### PR TITLE
Tell user they are in private channel when using active command

### DIFF
--- a/src/discordtipbot/discordbot.cr
+++ b/src/discordtipbot/discordbot.cr
@@ -397,6 +397,8 @@ class DiscordBot
   end
 
   def active(msg : Discord::Message)
+    return reply(msg, "You cannot use this command in a private channel!") if private?(msg)
+
     @bot.trigger_typing_indicator(msg.channel_id)
     authors = active_users(msg)
     return reply(msg, "No active users!") if authors.empty? || authors.nil?

--- a/src/discordtipbot/discordbot.cr
+++ b/src/discordtipbot/discordbot.cr
@@ -402,7 +402,9 @@ class DiscordBot
     @bot.trigger_typing_indicator(msg.channel_id)
     authors = active_users(msg)
     return reply(msg, "No active users!") if authors.empty? || authors.nil?
-    reply(msg, "There are **#{authors.size}** active users ATM")
+
+    singular = authors.size == 1
+    reply(msg, "There #{singular ? "is" : "are"} **#{authors.size}** active user#{singular ? "" : "s"} ATM")
   end
 
   # the users balance


### PR DESCRIPTION
Currently the bot will calculate the active users when the `~active` command is used in direct message - this doesn't need to happen because nobody else can be active here!

This commit makes the bot tell the user they are the only user active and then breaks, without performing any calculations.

**EDIT:** The bot will also use singular when there is only one active user.