### PR TITLE
Add CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: crystal
+script:
+  - crystal spec
+  - crystal tool format --check

--- a/spec/discordtipbot_spec.cr
+++ b/spec/discordtipbot_spec.cr
@@ -2,8 +2,4 @@ require "./spec_helper"
 
 describe Discordtipbot do
   # TODO: Write tests
-
-  it "works" do
-    false.should eq(true)
-  end
 end

--- a/src/discordtipbot/discordbot.cr
+++ b/src/discordtipbot/discordbot.cr
@@ -1,7 +1,7 @@
 class DiscordBot
   USER_REGEX = /<@!?(?<id>\d+)>/
   START_TIME = Time.now
-  TERMS = "In no event shall this bot or it's dev be responsible in the event of lost, stolen or misdirected funds."
+  TERMS      = "In no event shall this bot or it's dev be responsible in the event of lost, stolen or misdirected funds."
 
   def initialize(@config : Config, @log : Logger)
     @log.debug("#{@config.coinname_short}: starting bot: #{@config.coinname_full}")


### PR DESCRIPTION
Adds a basic setup for Travis CI that runs the spec suite and the formatter check. I've run the formatter and removed the default failing spec so that CI should pass upon enabling.