### PR TITLE
Only check format of src and spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: crystal
 script:
   - crystal spec
-  - crystal tool format --check
+  - crystal tool format --check src
+  - crystal tool format --check spec


### PR DESCRIPTION
This should fix CI. We shouldn't be checking format of `lib/`.