### PR TITLE
Split messages into parts when they are 2000 characters or more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: crystal
+env:
+  - TIPBOT_ENV=test
 script:
   - crystal spec
   - crystal tool format --check src

--- a/spec/utilites_spec.cr
+++ b/spec/utilites_spec.cr
@@ -1,0 +1,42 @@
+require "./spec_helper"
+
+class UtilityBot
+  include Utilities
+end
+
+describe Utilities do
+  bot = UtilityBot.new
+
+  describe "#split" do
+    context "with a message 2000 characters or less" do
+      it "doesn't split" do
+        message = "a" * 2000
+        bot.split(message).should eq [message]
+      end
+    end
+
+    context "with a message over 2000 characters" do
+      it "splits into multiple messages" do
+        messages = [
+          "a" * 2000,
+          "b" * 2000,
+          "c" * 2000,
+        ]
+        message = messages.join
+        bot.split(message).should eq messages
+      end
+    end
+  end
+
+  describe "#build_user_string" do
+    context "mention is false" do
+      pending "builds a string of usernames" do
+      end
+    end
+
+    context "mention is true" do
+      pending "builds a string of mentions" do
+      end
+    end
+  end
+end

--- a/src/discordtipbot.cr
+++ b/src/discordtipbot.cr
@@ -4,29 +4,31 @@ require "logger"
 require "pg"
 require "discordcr"
 
-puts "No Config File specified! Exiting!" if ARGV.size == 0
-exit if ARGV.size == 0
+unless ENV["TIPBOT_ENV"]? == "test"
+  puts "No Config File specified! Exiting!" if ARGV.size == 0
+  exit if ARGV.size == 0
 
-log = Logger.new(STDOUT)
+  log = Logger.new(STDOUT)
 
-# Set your logger level here
-log.level = Logger::DEBUG
+  # Set your logger level here
+  log.level = Logger::DEBUG
 
-log.debug("Tipbot network getting started")
+  log.debug("Tipbot network getting started")
 
-log.debug("Attempting to read config from \"#{ARGV[0]}\"")
-config = File.open(ARGV[0], "r") do |file|
-  Array(Config).from_json(file)
-end
-log.info("read config from \"#{ARGV[0]}\"")
-
-log.debug("starting forking")
-bots = config.each do |x|
-  spawn do
-    Controller.new(x, log)
+  log.debug("Attempting to read config from \"#{ARGV[0]}\"")
+  config = File.open(ARGV[0], "r") do |file|
+    Array(Config).from_json(file)
   end
-end
-log.debug("finished forking")
+  log.info("read config from \"#{ARGV[0]}\"")
 
-log.info("All bots should be running now")
-sleep
+  log.debug("starting forking")
+  bots = config.each do |x|
+    spawn do
+      Controller.new(x, log)
+    end
+  end
+  log.debug("finished forking")
+
+  log.info("All bots should be running now")
+  sleep
+end

--- a/src/discordtipbot/discordbot.cr
+++ b/src/discordtipbot/discordbot.cr
@@ -1,4 +1,8 @@
+require "./utilities"
+
 class DiscordBot
+  include Utilities
+
   USER_REGEX = /<@!?(?<id>\d+)>/
   START_TIME = Time.now
   TERMS      = "In no event shall this bot or it's dev be responsible in the event of lost, stolen or misdirected funds."
@@ -136,31 +140,6 @@ class DiscordBot
         end
       end
     end
-  end
-
-  private def split(msg : String, message_break : String | Char, max_length : Int32 = 2000)
-    msgs = Array(String).new
-
-    # Break up the message into parts which are less than max_length characters each
-    while (msg.size > max_length)
-      # Calculate where to break the message and then record it
-      first_break = msg[0, max_length].rindex(message_break) || max_length
-      msgs << msg[0, first_break]
-
-      # Find the index of the next space after the first_break
-      next_break = msg.index(message_break, first_break).try { |v| v + 1 } || 0
-
-      # If the next space is more than max_length away just record it as the break first_break.
-      # FIXME: This will cause problems if a word is longer than max_length as it will shorten
-      #          the word because it will not fit into a single message.
-      next_break = first_break if next_break < first_break || next_break > first_break + max_length
-
-      # Split the message at this next space to prepare it for the following iteration
-      msg = msg[next_break, msg.size - next_break]
-    end
-    msgs << msg
-
-    msgs
   end
 
   # Since there is no easy way, just to reply to a message
@@ -432,19 +411,8 @@ class DiscordBot
     end
   end
 
-  private def build_user_string(mention : Bool, users : Set(UInt64) | Array(UInt64))
-    string = String.build do |str|
-      if mention
-        users.each { |x| str << "<@#{x}>, " }
-      else
-        users.each { |x| str << "#{@cache.resolve_user(x).username}, " }
-      end
-    end
-    string.rchop(", ")
-  end
-
   private def get_config_mention(msg : Discord::Message)
-    get_config(msg, "mention")
+    @tip.get_config(guild_id(msg), "mention") || false
   end
 
   private def get_config(msg : Discord::Message, memo : String)

--- a/src/discordtipbot/discordbot.cr
+++ b/src/discordtipbot/discordbot.cr
@@ -144,16 +144,14 @@ class DiscordBot
 
   # Since there is no easy way, just to reply to a message
   private def reply(payload : Discord::Message, msg : String)
-    begin
-      if msg.size > 2000
-        msgs = split(msg, ' ')
-        msgs.each { |x| @bot.create_message(payload.channel_id, x) }
-      else
-        @bot.create_message(payload.channel_id, msg)
-      end
-    rescue
-      @log.warn("#{@config.coinname_short}: bot failed sending a msg to #{payload.channel_id} with text: #{msg}")
+    if msg.size > 2000
+      msgs = split(msg, ' ')
+      msgs.each { |x| @bot.create_message(payload.channel_id, x) }
+    else
+      @bot.create_message(payload.channel_id, msg)
     end
+  rescue
+    @log.warn("#{@config.coinname_short}: bot failed sending a msg to #{payload.channel_id} with text: #{msg}")
   end
 
   private def dm_deposit(userid : UInt64)

--- a/src/discordtipbot/discordbot.cr
+++ b/src/discordtipbot/discordbot.cr
@@ -145,7 +145,7 @@ class DiscordBot
   # Since there is no easy way, just to reply to a message
   private def reply(payload : Discord::Message, msg : String)
     if msg.size > 2000
-      msgs = split(msg, ' ')
+      msgs = split(msg)
       msgs.each { |x| @bot.create_message(payload.channel_id, x) }
     else
       @bot.create_message(payload.channel_id, msg)

--- a/src/discordtipbot/discordbot.cr
+++ b/src/discordtipbot/discordbot.cr
@@ -138,10 +138,40 @@ class DiscordBot
     end
   end
 
+  private def split(msg : String, message_break : String | Char, max_length : Int32 = 2000)
+    msgs = Array(String).new
+
+    # Break up the message into parts which are less than max_length characters each
+    while (msg.size > max_length)
+      # Calculate where to break the message and then record it
+      first_break = msg[0, max_length].rindex(message_break) || max_length
+      msgs << msg[0, first_break]
+
+      # Find the index of the next space after the first_break
+      next_break = msg.index(message_break, first_break).try { |v| v + 1 } || 0
+
+      # If the next space is more than max_length away just record it as the break first_break.
+      # FIXME: This will cause problems if a word is longer than max_length as it will shorten
+      #          the word because it will not fit into a single message.
+      next_break = first_break if next_break < first_break || next_break > first_break + max_length
+
+      # Split the message at this next space to prepare it for the following iteration
+      msg = msg[next_break, msg.size - next_break]
+    end
+    msgs << msg
+
+    msgs
+  end
+
   # Since there is no easy way, just to reply to a message
   private def reply(payload : Discord::Message, msg : String)
     begin
-      @bot.create_message(payload.channel_id, msg)
+      if msg.size > 2000
+        msgs = split(msg, ' ')
+        msgs.each { |x| @bot.create_message(payload.channel_id, x) }
+      else
+        @bot.create_message(payload.channel_id, msg)
+      end
     rescue
       @log.warn("#{@config.coinname_short}: bot failed sending a msg to #{payload.channel_id} with text: #{msg}")
     end

--- a/src/discordtipbot/utilities.cr
+++ b/src/discordtipbot/utilities.cr
@@ -1,0 +1,40 @@
+# Mixin for wrapping various common tasks
+module Utilities
+  # Utility for splitting a long string over 2000 characters into multiple messages
+  def split(msg : String, message_break : String | Char = ' ', max_length : Int32 = 2000)
+    msgs = Array(String).new
+
+    # Break up the message into parts which are less than max_length characters each
+    while (msg.size > max_length)
+      # Calculate where to break the message and then record it
+      first_break = msg[0, max_length].rindex(message_break) || max_length
+      msgs << msg[0, first_break]
+
+      # Find the index of the next space after the first_break
+      next_break = msg.index(message_break, first_break).try { |v| v + 1 } || 0
+
+      # If the next space is more than max_length away just record it as the break first_break.
+      # FIXME: This will cause problems if a word is longer than max_length as it will shorten
+      #          the word because it will not fit into a single message.
+      next_break = first_break if next_break < first_break || next_break > first_break + max_length
+
+      # Split the message at this next space to prepare it for the following iteration
+      msg = msg[next_break, msg.size - next_break]
+    end
+    msgs << msg
+
+    msgs
+  end
+
+  # Builds a comma seperated list of user names or mentions
+  def build_user_string(mention : Bool, users : Set(UInt64) | Array(UInt64))
+    string = String.build do |str|
+      if mention
+        users.each { |x| str << "<@#{x}>, " }
+      else
+        users.each { |x| str << "#{@cache.resolve_user(x).username}, " }
+      end
+    end
+    string.rchop(", ")
+  end
+end


### PR DESCRIPTION
Using the code found [here](https://stackoverflow.com/a/7624821/1908134) as an example I have written a `split(msg, spliterator, max_length)` function to split long messages into parts if they do not fit into a standard Discord message (max. 2000 chars).

After some basic testing it was found to perform well, unless a word (characters without spaces) was encountered longer than the `max_length` parameter. If the word is longer than `max_length` it will be shortened. This could be fixed in the future but is unlikely to be an issue at the moment.

This resolves #19.