### PR TITLE
Split commands on arbitrary lengths of whitespace

### DIFF
--- a/src/discordtipbot/discordbot.cr
+++ b/src/discordtipbot/discordbot.cr
@@ -363,7 +363,7 @@ class DiscordBot
 
     cmd_usage = "`#{@config.prefix}tip [@user] [amount]`"
     # cmd[0]: trigger, cmd[1]: user, cmd[2]: amount
-    cmd = cmd_string.split(" ")
+    cmd = cmd_string.split(' ', remove_empty: true)
 
     return reply(msg, "**ERROR**: Usage: #{cmd_usage}") unless cmd.size > 2
 


### PR DESCRIPTION
This change will prevent commands from breaking if there are too many spaces between arguments.